### PR TITLE
remove From<u8> bound for AggregateMetric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "metricator"
-version = "0.0.6"
+version = "0.0.7"
 edition = "2021"
 license = "MIT"
 description = "Metrics"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,10 @@ repository = "https://github.com/piot/metricator"
 
 [dependencies]
 num-traits = "0.2"
-monotonic-time-rs = "0.0.9"
+monotonic-time-rs = "0.0.10"
 
 [dev-dependencies]
 test-log = "0.2.18"
+
+[patch.crates-io]
+monotonic-time-rs = { git = "https://github.com/skewballfox/monotonic-time-rs.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/piot/metricator"
 
 [dependencies]
 num-traits = "0.2"
-monotonic-time-rs = "0.0.5"
+monotonic-time-rs = "0.0.9"
 
 [dev-dependencies]
-test-log = "0.2.16"
+test-log = "0.2.18"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -148,7 +148,6 @@ where
         + Copy
         + PartialOrd
         + Default
-        + From<u8>
         + Debug
         + Display
         + Bounded


### PR DESCRIPTION
This should wait until a related PR for monotonic-time-rs is merged, given this has a cargo patch and bumps that crate to a nonexistent version. 
- removes the `From<u8>` bound for the Generic wrapped by AggregateMetric, given that none of the implemented methods convert a u8 to the underlying type. 